### PR TITLE
Add Raffle Power Column to Stakers Data

### DIFF
--- a/src/components/Dashboard/StakersList.tsx
+++ b/src/components/Dashboard/StakersList.tsx
@@ -125,7 +125,20 @@ export function StakersList({ stakers, loading }: StakersListProps) {
               <th>Legendary Lords</th>
               <th>Mystic Lords</th>
               <th>Total Lords</th>
-              <th className="raffle-power-col">Raffle Power</th>
+              <th className="raffle-power-col">
+                <div className="tooltip">
+                  Raffle Power
+                  <span className="tooltip-text">
+                    <strong>Raffle Power Calculation:</strong><br />
+                    • Rare: 1 ticket × days staked<br />
+                    • Epic: 2 tickets × days staked<br />
+                    • Legendary: 4 tickets × days staked<br />
+                    • Mystic: 8 tickets × days staked<br />
+                    <br />
+                    Higher raffle power = better chances in raffles
+                  </span>
+                </div>
+              </th>
             </tr>
           </thead>
           <tbody>

--- a/src/components/Dashboard/StakersList.tsx
+++ b/src/components/Dashboard/StakersList.tsx
@@ -34,6 +34,11 @@ export function StakersList({ stakers, loading }: StakersListProps) {
   const formatAddress = (address: string) => {
     return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
   };
+  
+  // Format large numbers with thousands separators
+  const formatNumber = (num: number) => {
+    return num.toLocaleString();
+  };
 
   const renderHeader = () => (
     <div className="card-header">
@@ -71,11 +76,13 @@ export function StakersList({ stakers, loading }: StakersListProps) {
                 <th>Legendary Lords</th>
                 <th>Mystic Lords</th>
                 <th>Total Lords</th>
+                <th className="raffle-power-col">Raffle Power</th>
               </tr>
             </thead>
             <tbody>
               {Array.from({ length: 10 }).map((_, index) => (
                 <tr key={index} className="skeleton-row">
+                  <td><div className="skeleton-line"></div></td>
                   <td><div className="skeleton-line"></div></td>
                   <td><div className="skeleton-line"></div></td>
                   <td><div className="skeleton-line"></div></td>
@@ -118,6 +125,7 @@ export function StakersList({ stakers, loading }: StakersListProps) {
               <th>Legendary Lords</th>
               <th>Mystic Lords</th>
               <th>Total Lords</th>
+              <th className="raffle-power-col">Raffle Power</th>
             </tr>
           </thead>
           <tbody>
@@ -138,6 +146,7 @@ export function StakersList({ stakers, loading }: StakersListProps) {
                 <td className="legendary">{staker.legendaryLords}</td>
                 <td className="mystic">{staker.mysticLords}</td>
                 <td className="total">{staker.totalLords}</td>
+                <td className="raffle-power">{formatNumber(staker.rafflePower)}</td>
               </tr>
             ))}
           </tbody>

--- a/src/styles/stakers.css
+++ b/src/styles/stakers.css
@@ -53,6 +53,17 @@
   font-weight: bold;
 }
 
+/* Raffle Power column styling */
+.stakers-table .raffle-power-col {
+  background-color: rgba(255, 215, 0, 0.1);
+}
+
+.stakers-table .raffle-power {
+  font-weight: bold;
+  color: #FFA500;
+  font-size: 1.05rem;
+}
+
 .skeleton-row td {
   height: 30px;
 }
@@ -66,6 +77,41 @@
   animation: pulse 1.5s infinite;
 }
 
+/* Tooltip for raffle power explanation */
+.tooltip {
+  position: relative;
+  display: inline-block;
+  cursor: help;
+}
+
+.tooltip .tooltip-text {
+  visibility: hidden;
+  width: 280px;
+  background-color: var(--card-bg);
+  color: var(--text-light);
+  text-align: left;
+  border-radius: 6px;
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 20;
+  bottom: 125%;
+  left: 50%;
+  transform: translateX(-50%);
+  
+  /* Fade in tooltip */
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.tooltip:hover .tooltip-text {
+  visibility: visible;
+  opacity: 1;
+}
+
 @media (max-width: 768px) {
   .stakers-table {
     font-size: 0.8rem;
@@ -74,5 +120,9 @@
   .stakers-table th,
   .stakers-table td {
     padding: 0.5rem;
+  }
+  
+  .stakers-table .raffle-power {
+    font-size: 0.9rem;
   }
 }


### PR DESCRIPTION
This PR adds a Raffle Power column to the Stakers Data page. The Raffle Power is calculated based on the formula:

- Rare Lord: 1 ticket × days staked
- Epic Lord: 2 tickets × days staked
- Legendary Lord: 4 tickets × days staked
- Mystic Lord: 8 tickets × days staked

## Changes:
- Updated the `useStakersData` hook to calculate Raffle Power for each staker
- Added the Raffle Power column to the Stakers table
- Added custom styling for the Raffle Power column to highlight its importance
- Added a tooltip that explains the Raffle Power calculation when hovering over the column header

The stakers are now sorted by Raffle Power (highest first), providing an easy way to see who has the most accumulated power based on their staked Lords.

A tooltip has been added to explain the calculation formula to users.