### PR TITLE
Add CSV Export Feature for Stakers Data

### DIFF
--- a/src/components/Dashboard/StakersList.tsx
+++ b/src/components/Dashboard/StakersList.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { StakerData } from '../../hooks/useStakersData';
+import { useExportStakers } from '../../hooks/useExportStakers';
 
 interface StakersListProps {
   stakers: StakerData[];
@@ -12,6 +13,7 @@ export function StakersList({ stakers, loading }: StakersListProps) {
   const [filteredStakers, setFilteredStakers] = useState<StakerData[]>(stakers);
   
   const itemsPerPage = 25;
+  const exportStakers = useExportStakers();
 
   useEffect(() => {
     if (searchTerm === '') {
@@ -39,6 +41,11 @@ export function StakersList({ stakers, loading }: StakersListProps) {
   const formatNumber = (num: number) => {
     return num.toLocaleString();
   };
+  
+  const handleExport = () => {
+    // Export all stakers data, not just the current page
+    exportStakers(searchTerm ? filteredStakers : stakers);
+  };
 
   const renderHeader = () => (
     <div className="card-header">
@@ -49,7 +56,7 @@ export function StakersList({ stakers, loading }: StakersListProps) {
             : `Showing ${indexOfFirstItem + 1}-${Math.min(indexOfLastItem, filteredStakers.length)} of ${filteredStakers.length} Stakers`}
         </div>
         
-        <div className="header-controls w-full md:w-auto">
+        <div className="header-controls w-full md:w-auto flex flex-col md:flex-row gap-2">
           <input
             type="text"
             placeholder="Search by address..."
@@ -57,6 +64,17 @@ export function StakersList({ stakers, loading }: StakersListProps) {
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
+          
+          <button
+            className="btn btn-secondary export-btn"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleExport();
+            }}
+            disabled={loading || stakers.length === 0}
+          >
+            Export to CSV
+          </button>
         </div>
       </div>
     </div>

--- a/src/hooks/useExportStakers.ts
+++ b/src/hooks/useExportStakers.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { StakerData } from './useStakersData';
+import { exportToCsv } from '../utils/exportToCsv';
+
+export function useExportStakers() {
+  const prepareData = useCallback((stakers: StakerData[]) => {
+    return stakers.map(staker => ({
+      'Wallet Address': staker.address,
+      'Rare Lords': staker.rareLords,
+      'Epic Lords': staker.epicLords,
+      'Legendary Lords': staker.legendaryLords,
+      'Mystic Lords': staker.mysticLords,
+      'Total Lords': staker.totalLords,
+      'Raffle Power': staker.rafflePower
+    }));
+  }, []);
+
+  const exportStakers = useCallback((stakers: StakerData[]) => {
+    if (!stakers || stakers.length === 0) {
+      alert('No data available to export');
+      return;
+    }
+
+    const date = new Date().toISOString().split('T')[0];
+    const filename = `wild-forest-stakers-${date}.csv`;
+    
+    const exportData = prepareData(stakers);
+    exportToCsv(exportData, filename);
+  }, [prepareData]);
+
+  return exportStakers;
+}

--- a/src/styles/stakers.css
+++ b/src/styles/stakers.css
@@ -64,6 +64,37 @@
   font-size: 1.05rem;
 }
 
+/* Export button styling */
+.export-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem 1rem;
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.25rem;
+  color: var(--text-light);
+  transition: all 0.2s ease;
+  cursor: pointer;
+  font-weight: 500;
+  min-width: 120px;
+}
+
+.export-btn::before {
+  content: "📊";
+  margin-right: 0.5rem;
+}
+
+.export-btn:hover {
+  background-color: var(--hover-bg);
+  color: var(--primary-light);
+}
+
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .skeleton-row td {
   height: 30px;
 }
@@ -124,5 +155,14 @@
   
   .stakers-table .raffle-power {
     font-size: 0.9rem;
+  }
+  
+  .header-controls {
+    margin-top: 0.5rem;
+  }
+  
+  .export-btn {
+    width: 100%;
+    margin-top: 0.5rem;
   }
 }


### PR DESCRIPTION
This PR adds a CSV export feature to the Stakers Data page. This allows users to download the entire stakers table with all the data (including Raffle Power) as a CSV file that can be opened in Google Sheets, Microsoft Excel, or any other spreadsheet application.

## Changes:
- Added a new `useExportStakers` hook that handles the CSV export functionality
- Added an "Export to CSV" button to the Stakers Data page
- The exported CSV includes all staker information:
  - Wallet address
  - Number of lords by rarity (Rare, Epic, Legendary, Mystic)
  - Total lords
  - Raffle Power score
- Added styling for the export button with a chart icon 📊

The export functionality works with both the full dataset and filtered results (when using the search function). The exported filename includes the current date for easier tracking.