### PR TITLE
Add visual highlighting for invalid Ethereum addresses

### DIFF
--- a/src/components/Raffle/AddressInput.tsx
+++ b/src/components/Raffle/AddressInput.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 interface AddressInputProps {
   onSubmitAddresses: (addresses: string[]) => void;
@@ -6,27 +6,94 @@ interface AddressInputProps {
   error: string | null;
 }
 
+interface AddressValidation {
+  text: string;
+  isValid: boolean;
+  errorReason?: string;
+}
+
 export function AddressInput({ onSubmitAddresses, isProcessing, error }: AddressInputProps) {
   const [addressText, setAddressText] = useState('');
-  const [addressCount, setAddressCount] = useState(0);
-  const [uniqueAddressCount, setUniqueAddressCount] = useState(0);
   const [lineCount, setLineCount] = useState(0);
+  const [validAddressCount, setValidAddressCount] = useState(0);
+  const [uniqueAddressCount, setUniqueAddressCount] = useState(0);
+  const [validatedLines, setValidatedLines] = useState<AddressValidation[]>([]);
+  const [highlightedText, setHighlightedText] = useState('');
+  
+  // Process and validate the input text
+  useEffect(() => {
+    if (!addressText.trim()) {
+      setValidatedLines([]);
+      setLineCount(0);
+      setValidAddressCount(0);
+      setUniqueAddressCount(0);
+      setHighlightedText('');
+      return;
+    }
+    
+    // Split text into lines and validate each line
+    const lines = addressText.split(/\r?\n/).filter(line => line.trim() !== '');
+    setLineCount(lines.length);
+    
+    const validations: AddressValidation[] = [];
+    const validAddresses: string[] = [];
+    
+    lines.forEach(line => {
+      // Check if the line contains a valid Ethereum address
+      const ethAddressRegex = /^0x[a-fA-F0-9]{40}$/;
+      const trimmedLine = line.trim();
+      
+      if (ethAddressRegex.test(trimmedLine)) {
+        validations.push({ text: trimmedLine, isValid: true });
+        validAddresses.push(trimmedLine.toLowerCase());
+      } else {
+        // If invalid, determine why
+        let errorReason = 'Invalid format';
+        
+        if (trimmedLine.includes(' ')) {
+          errorReason = 'Contains spaces';
+        } else if (trimmedLine.length > 42) {
+          errorReason = 'Too long';
+        } else if (trimmedLine.length < 42) {
+          errorReason = 'Too short';
+        } else if (!trimmedLine.startsWith('0x')) {
+          errorReason = 'Missing 0x prefix';
+        } else if (!/^0x[a-fA-F0-9]*$/.test(trimmedLine)) {
+          errorReason = 'Contains invalid characters';
+        }
+        
+        validations.push({ text: trimmedLine, isValid: false, errorReason });
+      }
+    });
+    
+    setValidatedLines(validations);
+    setValidAddressCount(validAddresses.length);
+    
+    // Count unique addresses
+    const uniqueAddresses = [...new Set(validAddresses)];
+    setUniqueAddressCount(uniqueAddresses.length);
+    
+    // Create highlighted text for display
+    generateHighlightedText(validations);
+    
+  }, [addressText]);
+  
+  // Generate text with HTML highlighting for invalid addresses
+  const generateHighlightedText = (validations: AddressValidation[]) => {
+    // This won't be used directly in the textarea (which can't have HTML),
+    // but will be used for a read-only display mode if needed
+    const html = validations.map(v => 
+      v.isValid 
+        ? `<span class="valid-address">${v.text}</span>` 
+        : `<span class="invalid-address" title="${v.errorReason}">${v.text}</span>`
+    ).join('\n');
+    
+    setHighlightedText(html);
+  };
   
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const text = e.target.value;
     setAddressText(text);
-    
-    // Count lines
-    const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
-    setLineCount(lines.length);
-    
-    // Extract and count Ethereum addresses
-    const extractedAddresses = extractAddresses(text);
-    setAddressCount(extractedAddresses.length);
-    
-    // Count unique addresses
-    const uniqueAddresses = [...new Set(extractedAddresses)];
-    setUniqueAddressCount(uniqueAddresses.length);
   };
   
   const extractAddresses = (text: string): string[] => {
@@ -51,41 +118,15 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
     
     // Log details for debugging
     console.log(`Lines detected: ${lineCount}`);
-    console.log(`Total addresses extracted: ${extractedAddresses.length}`);
-    console.log(`Unique addresses: ${uniqueAddresses.length}`);
+    console.log(`Valid addresses extracted: ${validAddressCount}`);
+    console.log(`Unique addresses: ${uniqueAddressCount}`);
     
-    if (extractedAddresses.length < lineCount) {
+    if (validAddressCount < lineCount) {
       console.log("Some lines don't contain valid Ethereum addresses");
-      // Debug: Log the first 5 lines that don't have addresses
-      const lines = addressText.split(/\r?\n/).filter(line => line.trim() !== '');
-      const linesWithoutAddresses = lines.filter(line => {
-        const hasAddress = /0x[a-fA-F0-9]{40}/i.test(line);
-        return !hasAddress && line.trim() !== '';
-      });
       
-      console.log("Sample lines without valid addresses:");
-      linesWithoutAddresses.slice(0, 5).forEach((line, i) => {
-        console.log(`Line ${i+1}: "${line}"`);
-      });
-    }
-    
-    if (uniqueAddresses.length < extractedAddresses.length) {
-      console.log(`Found ${extractedAddresses.length - uniqueAddresses.length} duplicate addresses`);
-      
-      // Create a frequency map
-      const addressCount: Record<string, number> = {};
-      extractedAddresses.forEach(addr => {
-        addressCount[addr] = (addressCount[addr] || 0) + 1;
-      });
-      
-      // Find duplicates
-      const duplicates = Object.entries(addressCount)
-        .filter(([_, count]) => count > 1)
-        .map(([addr, count]) => ({ address: addr, count }));
-      
-      console.log("Duplicate addresses:");
-      duplicates.slice(0, 5).forEach(dup => {
-        console.log(`${dup.address} appears ${dup.count} times`);
+      // Log the invalid addresses
+      validatedLines.filter(v => !v.isValid).forEach((line, i) => {
+        console.log(`Invalid address ${i+1}: "${line.text}" - ${line.errorReason}`);
       });
     }
     
@@ -98,21 +139,43 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
       <div className="text-area-container">
         <textarea
           className="address-textarea"
-          placeholder="Paste wallet addresses here (0x...), one per line or separated by spaces, commas, etc."
+          placeholder="Paste wallet addresses here (0x...), one per line"
           value={addressText}
           onChange={handleTextChange}
           rows={10}
           disabled={isProcessing}
         />
         
+        {validatedLines.length > 0 && (
+          <div className="address-validation-overlay">
+            {validatedLines.map((validation, index) => (
+              <div 
+                key={index} 
+                className={`address-line ${validation.isValid ? 'valid-line' : 'invalid-line'}`}
+                title={validation.isValid ? 'Valid address' : validation.errorReason}
+              >
+                {validation.text}
+                {!validation.isValid && (
+                  <span className="error-tooltip">{validation.errorReason}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        
         <div className="address-count">
           {lineCount > 0 && (
             <div className="count-details">
               <div>Lines: {lineCount}</div>
-              <div>Addresses found: {addressCount}</div>
-              {addressCount !== uniqueAddressCount && (
+              <div className={validAddressCount < lineCount ? 'warning' : ''}>
+                Valid addresses: {validAddressCount}/{lineCount}
+                {validAddressCount < lineCount && (
+                  <span className="icon" title="Some lines contain invalid addresses">⚠️</span>
+                )}
+              </div>
+              {validAddressCount !== uniqueAddressCount && (
                 <div className="warning">
-                  Unique addresses: {uniqueAddressCount} ({addressCount - uniqueAddressCount} duplicates will be removed)
+                  Unique addresses: {uniqueAddressCount} ({validAddressCount - uniqueAddressCount} duplicates will be removed)
                 </div>
               )}
             </div>
@@ -120,12 +183,26 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
         </div>
       </div>
       
+      {validAddressCount < lineCount && (
+        <div className="error-message mt-2">
+          <strong>Warning:</strong> {lineCount - validAddressCount} line(s) contain invalid Ethereum addresses.
+          <ul className="invalid-address-list">
+            {validatedLines.filter(v => !v.isValid).slice(0, 5).map((v, i) => (
+              <li key={i}>"{v.text}" - {v.errorReason}</li>
+            ))}
+            {validatedLines.filter(v => !v.isValid).length > 5 && (
+              <li>...and {validatedLines.filter(v => !v.isValid).length - 5} more</li>
+            )}
+          </ul>
+        </div>
+      )}
+      
       {error && <div className="error-message mt-2">{error}</div>}
       
       <button
         className="btn btn-primary mt-4"
         onClick={handleSubmit}
-        disabled={isProcessing || uniqueAddressCount === 0}
+        disabled={isProcessing || validAddressCount === 0}
       >
         {isProcessing ? 'Processing...' : 'Prepare Raffle'}
       </button>
@@ -134,6 +211,7 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
         .address-input-container {
           width: 100%;
           margin-bottom: 1.5rem;
+          position: relative;
         }
         
         .text-area-container {
@@ -149,6 +227,58 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
           font-family: monospace;
           font-size: 0.875rem;
           resize: vertical;
+          line-height: 1.5;
+        }
+        
+        .address-validation-overlay {
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          pointer-events: none;
+          overflow: auto;
+          padding: 0.75rem;
+          font-family: monospace;
+          font-size: 0.875rem;
+          line-height: 1.5;
+          color: transparent;
+          background: transparent;
+        }
+        
+        .address-line {
+          position: relative;
+          white-space: pre;
+        }
+        
+        .valid-line {
+          /* No special styling for valid lines */
+        }
+        
+        .invalid-line {
+          position: relative;
+          background-color: rgba(255, 0, 0, 0.1);
+          border-radius: 0.25rem;
+          color: #e53e3e;
+          text-decoration: wavy underline #e53e3e;
+        }
+        
+        .error-tooltip {
+          display: none;
+          position: absolute;
+          right: 0;
+          top: 0;
+          background-color: #e53e3e;
+          color: white;
+          padding: 0.25rem 0.5rem;
+          border-radius: 0.25rem;
+          font-size: 0.75rem;
+          z-index: 10;
+          white-space: nowrap;
+        }
+        
+        .invalid-line:hover .error-tooltip {
+          display: block;
         }
         
         .address-count {
@@ -169,9 +299,24 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
           color: #e67e22;
         }
         
+        .icon {
+          margin-left: 0.25rem;
+        }
+        
         .error-message {
           color: #e53e3e;
           font-size: 0.875rem;
+          background-color: rgba(229, 62, 62, 0.1);
+          padding: 0.75rem;
+          border-radius: 0.25rem;
+          border-left: 4px solid #e53e3e;
+        }
+        
+        .invalid-address-list {
+          margin-top: 0.5rem;
+          margin-bottom: 0;
+          padding-left: 1.5rem;
+          font-size: 0.8rem;
         }
         
         .btn {


### PR DESCRIPTION
This PR adds address highlighting for invalid Ethereum addresses in the raffle address input.

## New Features:
- Visual highlighting of invalid addresses (red background with underline)
- Specific error messages for each invalid address (spaces, too long, too short, etc.)
- Error summary showing problematic addresses
- Tooltips with error details on hover

This makes it much easier for users to identify and correct issues with addresses, particularly when handling large lists of addresses pasted from various sources.

## Benefits:
- Instant visual feedback on invalid addresses
- Clear explanation of why an address is invalid
- Prevents errors before submitting the raffle
- Improves user experience by making problems obvious and fixable

This PR builds on the previously merged direct address input feature, adding the visual highlighting component that was developed after the initial PR was merged.