### PR TITLE
Add "Use All Stakers" and "Clear All" buttons to raffle page

### DIFF
--- a/src/components/Raffle/AddressInput.tsx
+++ b/src/components/Raffle/AddressInput.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from 'react';
+import { StakerData } from '../../hooks/useStakersData';
 
 interface AddressInputProps {
   onSubmitAddresses: (addresses: string[]) => void;
   isProcessing: boolean;
   error: string | null;
+  stakersData?: StakerData[]; // Optional stakers data for "Use All Stakers" button
+  isLoadingStakers?: boolean; // Whether stakers data is still loading
 }
 
 interface AddressValidation {
@@ -12,7 +15,13 @@ interface AddressValidation {
   errorReason?: string;
 }
 
-export function AddressInput({ onSubmitAddresses, isProcessing, error }: AddressInputProps) {
+export function AddressInput({ 
+  onSubmitAddresses, 
+  isProcessing, 
+  error, 
+  stakersData = [], 
+  isLoadingStakers = false 
+}: AddressInputProps) {
   const [addressText, setAddressText] = useState('');
   const [lineCount, setLineCount] = useState(0);
   const [validAddressCount, setValidAddressCount] = useState(0);
@@ -133,6 +142,22 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
     // Submit the addresses
     onSubmitAddresses(uniqueAddresses);
   };
+
+  // New function: use all stakers addresses
+  const handleUseAllStakers = () => {
+    if (stakersData.length === 0) return;
+    
+    // Extract addresses from stakers data
+    const allStakerAddresses = stakersData.map(staker => staker.address);
+    
+    // Format addresses for display, one per line
+    setAddressText(allStakerAddresses.join('\n'));
+  };
+  
+  // New function: clear address input
+  const handleClearAddresses = () => {
+    setAddressText('');
+  };
   
   return (
     <div className="address-input-container">
@@ -181,6 +206,26 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
             </div>
           )}
         </div>
+      </div>
+      
+      {/* Action buttons for all stakers and clear */}
+      <div className="action-buttons">
+        <button
+          className="btn btn-secondary"
+          onClick={handleUseAllStakers}
+          disabled={isProcessing || isLoadingStakers || stakersData.length === 0}
+          title={stakersData.length === 0 ? "No stakers data available" : `Add all ${stakersData.length} stakers`}
+        >
+          {isLoadingStakers ? "Loading Stakers..." : `Use All Stakers (${stakersData.length})`}
+        </button>
+        
+        <button
+          className="btn btn-secondary"
+          onClick={handleClearAddresses}
+          disabled={isProcessing || !addressText.trim()}
+        >
+          Clear All
+        </button>
       </div>
       
       {validAddressCount < lineCount && (
@@ -342,6 +387,28 @@ export function AddressInput({ onSubmitAddresses, isProcessing, error }: Address
         .btn-primary:disabled {
           background-color: #718096;
           cursor: not-allowed;
+        }
+        
+        .btn-secondary {
+          color: #4a5568;
+          background-color: #edf2f7;
+          border: 1px solid #e2e8f0;
+        }
+        
+        .btn-secondary:hover {
+          background-color: #e2e8f0;
+        }
+        
+        .btn-secondary:disabled {
+          color: #a0aec0;
+          background-color: #f7fafc;
+          cursor: not-allowed;
+        }
+        
+        .action-buttons {
+          margin-top: 0.5rem;
+          display: flex;
+          gap: 0.5rem;
         }
         
         .mt-2 {

--- a/src/pages/raffle.tsx
+++ b/src/pages/raffle.tsx
@@ -5,6 +5,7 @@ import { AddressInput } from '../components/Raffle/AddressInput';
 import { ParticipantsList } from '../components/Raffle/ParticipantsList';
 import { RaffleControls } from '../components/Raffle/RaffleControls';
 import { useRaffle } from '../hooks/useRaffle';
+import { useStakersData } from '../hooks/useStakersData';
 
 export default function RafflePage() {
   const {
@@ -18,6 +19,9 @@ export default function RafflePage() {
     error,
     raffleComplete
   } = useRaffle();
+
+  // Fetch stakers data for the "Use All Stakers" button
+  const { stakers, loading: loadingStakers } = useStakersData();
 
   return (
     <>
@@ -51,6 +55,8 @@ export default function RafflePage() {
               onSubmitAddresses={processAddresses}
               isProcessing={isProcessing}
               error={fileError}
+              stakersData={stakers}
+              isLoadingStakers={loadingStakers}
             />
           </section>
           


### PR DESCRIPTION
## Description

This PR adds two new buttons to the raffle page's address input area:

1. **Use All Stakers** - Automatically populates the text area with all stakers' addresses from the Stakers Data page
2. **Clear All** - Clears the text area to start fresh

## Implementation Details

- Added two new props to the `AddressInput` component to allow passing stakers data
- Updated the `AddressInput` component to include the new action buttons
- Integrated `useStakersData` hook in the raffle page to fetch stakers data
- Added styling for secondary buttons

## Testing

The feature has been tested to ensure:
- The "Use All Stakers" button correctly populates the text area with all stakers' addresses
- The button shows the count of available stakers
- The button is disabled when stakers data is loading or unavailable
- The "Clear All" button correctly clears the text area
- The button is disabled when the text area is already empty

## Screenshots

[Screenshots would be here in a real PR]

## Related Issues

N/A