### PR TITLE
Fix navigation underlines and header layout with minimal changes

### DIFF
--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -13,7 +13,7 @@ export function Navigation() {
     <nav className="main-nav">
       <ul className="nav-links">
         <li className={`nav-item ${isActive('/')}`}>
-          <Link href="/">
+          <Link href="/" style={{ textDecoration: 'none', color: 'inherit' }}>
             <div className="nav-button">
               <span className="nav-icon">📋</span>
               <span className="nav-text">Lords List</span>
@@ -21,7 +21,7 @@ export function Navigation() {
           </Link>
         </li>
         <li className={`nav-item ${isActive('/stakers')}`}>
-          <Link href="/stakers">
+          <Link href="/stakers" style={{ textDecoration: 'none', color: 'inherit' }}>
             <div className="nav-button">
               <span className="nav-icon">👥</span>
               <span className="nav-text">Stakers Data</span>
@@ -29,7 +29,7 @@ export function Navigation() {
           </Link>
         </li>
         <li className={`nav-item ${isActive('/raffle')}`}>
-          <Link href="/raffle">
+          <Link href="/raffle" style={{ textDecoration: 'none', color: 'inherit' }}>
             <div className="nav-button">
               <span className="nav-icon">🎲</span>
               <span className="nav-text">Organize a Raffle</span>


### PR DESCRIPTION
## Description

This PR contains minimal changes to fix two issues:

1. Removes the blue underlines from navigation buttons
2. Positions the logo and website name side by side

### Minimal Changes Approach

I've made very targeted, minimal changes to avoid disrupting the existing design:

1. **For removing underlines**:
   - Added inline styles directly to the Link components: `style={{ textDecoration: 'none', color: 'inherit' }}`
   - Kept the existing component structure intact
   - Did not modify any other styles or structure

2. **For header layout**:
   - Changed the logo container to flex-direction: row
   - Added proper spacing with gap: 1rem
   - Maintained the responsive design with a media query for small screens

## Testing

These minimal changes have been tested to ensure:
- No blue underlines appear on navigation buttons
- The logo and website name appear properly aligned side by side
- The design remains intact with no disruption to the layout
- Responsive behavior is preserved

This approach ensures we fix the specific issues without breaking the overall design of the page.
