### PR TITLE
Add dual raffle categories for Guarantee WL and FCFS WL

### DIFF
--- a/src/components/Raffle/RaffleControls.tsx
+++ b/src/components/Raffle/RaffleControls.tsx
@@ -145,34 +145,33 @@ export function RaffleControls({
           {/* Guarantee WL Winners */}
           {winners.filter(w => w.prizeType === 'Guarantee WL').length > 0 && (
             <div className="prize-category">
-              <div className="prize-header">
-                <div className="prize-icon guarantee-icon">🔐</div>
+              <div className="prize-header guarantee-header">
                 <h4>Guarantee WL Winners</h4>
               </div>
-              <div className="winners-grid guarantee-winners">
+              <div className="winners-grid">
                 {winners
                   .filter(winner => winner.prizeType === 'Guarantee WL')
                   .map((winner, index) => (
-                    <div key={winner.address} className="winner-card">
-                      <div className="card-top">
-                        <div className="winner-badge">{index + 1}</div>
-                        <a
-                          href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="contract-link"
-                        >
-                          {formatAddress(winner.address)}
-                        </a>
-                      </div>
-                      <div className="card-stats">
-                        <div className="stat-item">
-                          <span className="stat-label">Raffle Power:</span>
-                          <span className="stat-value">{winner.rafflePower.toLocaleString()}</span>
-                        </div>
-                        <div className="stat-item">
-                          <span className="stat-label">Win Chance:</span>
-                          <span className="stat-value">{winner.percentage.toFixed(2)}%</span>
+                    <div key={winner.address} className="winner-card guarantee-card">
+                      <div className="card-content">
+                        <div className="winner-rank">{index + 1}</div>
+                        <div className="winner-info">
+                          <a
+                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="wallet-address"
+                          >
+                            {formatAddress(winner.address)}
+                          </a>
+                          <div className="winner-stats">
+                            <div className="stat">
+                              <span>Power:</span> {winner.rafflePower.toLocaleString()}
+                            </div>
+                            <div className="stat">
+                              <span>Chance:</span> {winner.percentage.toFixed(2)}%
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -184,34 +183,33 @@ export function RaffleControls({
           {/* FCFS WL Winners */}
           {winners.filter(w => w.prizeType === 'FCFS WL').length > 0 && (
             <div className="prize-category">
-              <div className="prize-header">
-                <div className="prize-icon fcfs-icon">🏃</div>
+              <div className="prize-header fcfs-header">
                 <h4>FCFS WL Winners</h4>
               </div>
-              <div className="winners-grid fcfs-winners">
+              <div className="winners-grid">
                 {winners
                   .filter(winner => winner.prizeType === 'FCFS WL')
                   .map((winner, index) => (
-                    <div key={winner.address} className="winner-card">
-                      <div className="card-top">
-                        <div className="winner-badge">{index + 1}</div>
-                        <a
-                          href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="contract-link"
-                        >
-                          {formatAddress(winner.address)}
-                        </a>
-                      </div>
-                      <div className="card-stats">
-                        <div className="stat-item">
-                          <span className="stat-label">Raffle Power:</span>
-                          <span className="stat-value">{winner.rafflePower.toLocaleString()}</span>
-                        </div>
-                        <div className="stat-item">
-                          <span className="stat-label">Win Chance:</span>
-                          <span className="stat-value">{winner.percentage.toFixed(2)}%</span>
+                    <div key={winner.address} className="winner-card fcfs-card">
+                      <div className="card-content">
+                        <div className="winner-rank">{index + 1}</div>
+                        <div className="winner-info">
+                          <a
+                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="wallet-address"
+                          >
+                            {formatAddress(winner.address)}
+                          </a>
+                          <div className="winner-stats">
+                            <div className="stat">
+                              <span>Power:</span> {winner.rafflePower.toLocaleString()}
+                            </div>
+                            <div className="stat">
+                              <span>Chance:</span> {winner.percentage.toFixed(2)}%
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -314,214 +312,183 @@ export function RaffleControls({
         }
         
         .winners-title {
-          font-size: 1.8rem;
+          font-size: 1.5rem;
           font-weight: 700;
           margin-bottom: 1.5rem;
           text-align: center;
           color: #2d3748;
-          text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
         }
         
         .prize-category {
-          margin-bottom: 2rem;
-          border-radius: 0.75rem;
-          padding: 1.5rem;
-          background-color: #ffffff;
-          box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+          margin-bottom: 1.5rem;
+          border: 1px solid #e2e8f0;
+          border-radius: 0.5rem;
+          overflow: hidden;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         }
         
         .prize-header {
-          display: flex;
-          align-items: center;
-          margin-bottom: 1.5rem;
-          border-bottom: 2px solid #f7fafc;
-          padding-bottom: 1rem;
+          padding: 0.75rem 1rem;
+          border-bottom: 1px solid #e2e8f0;
         }
         
-        .prize-icon {
-          font-size: 1.5rem;
-          margin-right: 0.75rem;
-          width: 40px;
-          height: 40px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          border-radius: 50%;
+        .guarantee-header {
+          background-color: rgba(72, 187, 120, 0.1);
         }
         
-        .guarantee-icon {
-          background-color: rgba(72, 187, 120, 0.15);
-          color: #2f855a;
+        .fcfs-header {
+          background-color: rgba(237, 137, 54, 0.1);
         }
         
-        .fcfs-icon {
-          background-color: rgba(237, 137, 54, 0.15);
-          color: #c05621;
-        }
-        
-        .prize-category h4 {
-          font-size: 1.25rem;
+        .prize-header h4 {
+          font-size: 1rem;
           font-weight: 600;
-          color: #2d3748;
           margin: 0;
+          color: #2d3748;
         }
         
         .winners-grid {
           display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-          gap: 1rem;
+          grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+          gap: 0.5rem;
+          padding: 0.75rem;
+          background-color: #f8fafc;
         }
         
         .winner-card {
-          border-radius: 0.75rem;
+          background-color: white;
+          border-radius: 0.25rem;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
           overflow: hidden;
-          transition: all 0.3s ease;
-          display: flex;
-          flex-direction: column;
-          height: 100%;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
         
-        .guarantee-winners .winner-card {
-          background: linear-gradient(to bottom, #f0fff4, #ffffff);
-          border: 1px solid #c6f6d5;
+        .guarantee-card {
+          border-left: 3px solid #48bb78;
         }
         
-        .fcfs-winners .winner-card {
-          background: linear-gradient(to bottom, #fffaf0, #ffffff);
-          border: 1px solid #feebc8;
+        .fcfs-card {
+          border-left: 3px solid #ed8936;
         }
         
         .winner-card:hover {
-          transform: translateY(-3px);
-          box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+          transform: translateY(-2px);
+          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
         }
         
-        .card-top {
-          padding: 1rem;
+        .card-content {
           display: flex;
-          align-items: center;
-          position: relative;
+          padding: 0.75rem;
         }
         
-        .guarantee-winners .card-top {
-          background-color: rgba(72, 187, 120, 0.1);
-          border-bottom: 2px solid rgba(72, 187, 120, 0.2);
-        }
-        
-        .fcfs-winners .card-top {
-          background-color: rgba(237, 137, 54, 0.1);
-          border-bottom: 2px solid rgba(237, 137, 54, 0.2);
-        }
-        
-        .winner-badge {
-          width: 28px;
-          height: 28px;
+        .winner-rank {
+          width: 1.5rem;
+          height: 1.5rem;
+          background-color: #f7fafc;
           display: flex;
           align-items: center;
           justify-content: center;
-          border-radius: 50%;
-          font-weight: 800;
-          font-size: 0.9rem;
+          font-weight: 700;
+          font-size: 0.875rem;
+          color: #4a5568;
           margin-right: 0.75rem;
-          flex-shrink: 0;
+          border: 1px solid #e2e8f0;
         }
         
-        .guarantee-winners .winner-badge {
-          background-color: #48bb78;
-          color: white;
+        .guarantee-card .winner-rank {
+          color: #2f855a;
+          border-color: #c6f6d5;
+          background-color: #f0fff4;
         }
         
-        .fcfs-winners .winner-badge {
-          background-color: #ed8936;
-          color: white;
+        .fcfs-card .winner-rank {
+          color: #c05621;
+          border-color: #feebc8;
+          background-color: #fffaf0;
         }
         
-        .contract-link {
+        .winner-info {
+          flex: 1;
+          min-width: 0; /* Allow text truncation to work in flex child */
+        }
+        
+        .wallet-address {
+          display: block;
+          font-family: monospace;
+          font-size: 0.85rem;
           color: #4a5568;
           text-decoration: none;
-          font-family: monospace;
-          font-size: 0.9rem;
-          font-weight: 600;
-          transition: color 0.2s ease;
-          word-break: break-all;
+          margin-bottom: 0.5rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
         
-        .guarantee-winners .contract-link:hover {
+        .guarantee-card .wallet-address:hover {
           color: #2f855a;
         }
         
-        .fcfs-winners .contract-link:hover {
+        .fcfs-card .wallet-address:hover {
           color: #c05621;
         }
         
-        .card-stats {
-          padding: 1rem;
-          display: flex;
-          flex-direction: column;
-          gap: 0.5rem;
-          background-color: #ffffff;
-          height: 100%;
-        }
-        
-        .stat-item {
-          display: flex;
-          justify-content: space-between;
-          font-size: 0.85rem;
-        }
-        
-        .stat-label {
+        .winner-stats {
+          font-size: 0.75rem;
           color: #718096;
         }
         
-        .stat-value {
-          font-weight: 600;
-          color: #2d3748;
+        .stat {
+          display: flex;
+          justify-content: space-between;
         }
         
-        .guarantee-winners .stat-value {
-          color: #2f855a;
+        .stat span {
+          color: #a0aec0;
         }
         
-        .fcfs-winners .stat-value {
-          color: #c05621;
+        .guarantee-card .stat {
+          color: #38a169;
+        }
+        
+        .fcfs-card .stat {
+          color: #dd6b20;
         }
         
         .export-winners-container {
           display: flex;
           justify-content: center;
-          margin-top: 2rem;
+          margin-top: 1.5rem;
         }
         
         .export-winners-btn {
           display: flex;
           align-items: center;
-          gap: 0.75rem;
-          padding: 0.875rem 1.75rem;
+          gap: 0.5rem;
+          padding: 0.6rem 1.25rem;
           background-color: #4CAF50;
           color: white;
           border: none;
-          border-radius: 0.5rem;
+          border-radius: 0.25rem;
           font-weight: 600;
-          font-size: 1rem;
+          font-size: 0.9rem;
           cursor: pointer;
-          transition: all 0.3s ease;
-          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+          transition: all 0.2s ease;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         }
         
         .export-winners-btn:hover {
           background-color: #45a049;
-          transform: translateY(-2px);
-          box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
+          transform: translateY(-1px);
+          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
         
         .export-winners-btn:active {
           transform: translateY(0);
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
         }
         
         .export-icon {
-          font-size: 1.25rem;
+          font-size: 1.1rem;
         }
         
         @media (min-width: 640px) {

--- a/src/components/Raffle/RaffleControls.tsx
+++ b/src/components/Raffle/RaffleControls.tsx
@@ -146,30 +146,28 @@ export function RaffleControls({
           {winners.filter(w => w.prizeType === 'Guarantee WL').length > 0 && (
             <div className="prize-category">
               <h4>Guarantee WL Winners</h4>
-              <div className="winners-list guarantee-winners">
+              <div className="winners-grid guarantee-winners">
                 {winners
                   .filter(winner => winner.prizeType === 'Guarantee WL')
                   .map((winner, index) => (
                     <div key={winner.address} className="winner-card">
                       <div className="winner-number">#{index + 1}</div>
-                      <div className="winner-info">
-                        <div className="winner-address">
-                          <a
-                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="contract-link"
-                          >
-                            {formatAddress(winner.address)}
-                          </a>
+                      <div className="winner-address">
+                        <a
+                          href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="contract-link"
+                        >
+                          {formatAddress(winner.address)}
+                        </a>
+                      </div>
+                      <div className="winner-stats">
+                        <div className="winner-power">
+                          Power: {winner.rafflePower.toLocaleString()}
                         </div>
-                        <div className="winner-stats">
-                          <span className="winner-power">
-                            Raffle Power: {winner.rafflePower.toLocaleString()}
-                          </span>
-                          <span className="winner-chance">
-                            Win Chance: {winner.percentage.toFixed(2)}%
-                          </span>
+                        <div className="winner-chance">
+                          Chance: {winner.percentage.toFixed(2)}%
                         </div>
                       </div>
                     </div>
@@ -182,30 +180,28 @@ export function RaffleControls({
           {winners.filter(w => w.prizeType === 'FCFS WL').length > 0 && (
             <div className="prize-category">
               <h4>FCFS WL Winners</h4>
-              <div className="winners-list fcfs-winners">
+              <div className="winners-grid fcfs-winners">
                 {winners
                   .filter(winner => winner.prizeType === 'FCFS WL')
                   .map((winner, index) => (
                     <div key={winner.address} className="winner-card">
                       <div className="winner-number">#{index + 1}</div>
-                      <div className="winner-info">
-                        <div className="winner-address">
-                          <a
-                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="contract-link"
-                          >
-                            {formatAddress(winner.address)}
-                          </a>
+                      <div className="winner-address">
+                        <a
+                          href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="contract-link"
+                        >
+                          {formatAddress(winner.address)}
+                        </a>
+                      </div>
+                      <div className="winner-stats">
+                        <div className="winner-power">
+                          Power: {winner.rafflePower.toLocaleString()}
                         </div>
-                        <div className="winner-stats">
-                          <span className="winner-power">
-                            Raffle Power: {winner.rafflePower.toLocaleString()}
-                          </span>
-                          <span className="winner-chance">
-                            Win Chance: {winner.percentage.toFixed(2)}%
-                          </span>
+                        <div className="winner-chance">
+                          Chance: {winner.percentage.toFixed(2)}%
                         </div>
                       </div>
                     </div>
@@ -330,46 +326,41 @@ export function RaffleControls({
           border-bottom: 1px solid #e2e8f0;
         }
         
-        .winners-list {
-          display: flex;
-          flex-direction: column;
-          gap: 0.5rem;
+        .winners-grid {
+          display: grid;
+          grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+          gap: 1rem;
         }
         
         .winner-card {
-          display: flex;
-          padding: 0.75rem;
-          border-radius: 0.25rem;
+          border-radius: 0.375rem;
+          padding: 1rem;
           box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+          display: flex;
+          flex-direction: column;
         }
         
         .guarantee-winners .winner-card {
           background-color: rgba(72, 187, 120, 0.1);
-          border-left: 4px solid #48bb78;
+          border-top: 4px solid #48bb78;
         }
         
         .fcfs-winners .winner-card {
           background-color: rgba(237, 137, 54, 0.1);
-          border-left: 4px solid #ed8936;
+          border-top: 4px solid #ed8936;
         }
         
         .winner-number {
           font-weight: 700;
           font-size: 1.2rem;
-          margin-right: 1rem;
-          width: 2rem;
-          text-align: center;
-          align-self: center;
           color: #2d3748;
-        }
-        
-        .winner-info {
-          flex: 1;
+          margin-bottom: 0.5rem;
         }
         
         .winner-address {
           font-family: monospace;
-          margin-bottom: 0.25rem;
+          margin-bottom: 0.75rem;
+          word-break: break-all;
         }
         
         .contract-link {
@@ -382,10 +373,13 @@ export function RaffleControls({
         }
         
         .winner-stats {
-          display: flex;
-          gap: 1rem;
           font-size: 0.8rem;
           color: #718096;
+          margin-top: auto;
+        }
+        
+        .winner-power, .winner-chance {
+          margin-bottom: 0.25rem;
         }
         
         .export-winners-container {

--- a/src/components/Raffle/RaffleControls.tsx
+++ b/src/components/Raffle/RaffleControls.tsx
@@ -4,7 +4,7 @@ import { exportWinnersToCSV } from '../../utils/exportWinners';
 
 interface RaffleControlsProps {
   participants: Participant[];
-  onConductRaffle: (numWinners: number) => void;
+  onConductRaffle: (guaranteeWinners: number, fcfsWinners: number) => void;
   isDrawing: boolean;
   winners: Participant[];
   raffleComplete: boolean;
@@ -17,7 +17,8 @@ export function RaffleControls({
   winners,
   raffleComplete
 }: RaffleControlsProps) {
-  const [numWinners, setNumWinners] = useState(1);
+  const [guaranteeWinners, setGuaranteeWinners] = useState(1);
+  const [fcfsWinners, setFcfsWinners] = useState(1);
   
   // Calculate the max possible winners (can't be more than participants)
   const maxWinners = participants.length;
@@ -27,15 +28,22 @@ export function RaffleControls({
     return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
   };
   
-  const handleNumWinnersChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleGuaranteeWinnersChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value);
-    if (!isNaN(value) && value >= 1 && value <= maxWinners) {
-      setNumWinners(value);
+    if (!isNaN(value) && value >= 0 && value + fcfsWinners <= maxWinners) {
+      setGuaranteeWinners(value);
+    }
+  };
+  
+  const handleFcfsWinnersChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value);
+    if (!isNaN(value) && value >= 0 && value + guaranteeWinners <= maxWinners) {
+      setFcfsWinners(value);
     }
   };
   
   const handleStartRaffle = () => {
-    onConductRaffle(numWinners);
+    onConductRaffle(guaranteeWinners, fcfsWinners);
   };
   
   const handleExportWinners = () => {
@@ -50,32 +58,66 @@ export function RaffleControls({
     <div className="raffle-controls-container">
       <div className="raffle-controls">
         <div className="control-group">
-          <label htmlFor="numWinners" className="control-label">
-            Number of Winners:
+          <label htmlFor="guaranteeWinners" className="control-label">
+            Guarantee WL Winners:
           </label>
           <div className="number-input-group">
             <input
               type="number"
-              id="numWinners"
+              id="guaranteeWinners"
               className="number-input"
-              value={numWinners}
-              min={1}
-              max={maxWinners}
-              onChange={handleNumWinnersChange}
+              value={guaranteeWinners}
+              min={0}
+              max={maxWinners - fcfsWinners}
+              onChange={handleGuaranteeWinnersChange}
               disabled={isDrawing || raffleComplete}
             />
             <div className="number-controls">
               <button 
                 className="number-control" 
-                onClick={() => setNumWinners(prev => Math.min(prev + 1, maxWinners))}
-                disabled={numWinners >= maxWinners || isDrawing || raffleComplete}
+                onClick={() => setGuaranteeWinners(prev => Math.min(prev + 1, maxWinners - fcfsWinners))}
+                disabled={guaranteeWinners + fcfsWinners >= maxWinners || isDrawing || raffleComplete}
               >
                 ▲
               </button>
               <button 
                 className="number-control" 
-                onClick={() => setNumWinners(prev => Math.max(prev - 1, 1))}
-                disabled={numWinners <= 1 || isDrawing || raffleComplete}
+                onClick={() => setGuaranteeWinners(prev => Math.max(prev - 1, 0))}
+                disabled={guaranteeWinners <= 0 || isDrawing || raffleComplete}
+              >
+                ▼
+              </button>
+            </div>
+          </div>
+        </div>
+        
+        <div className="control-group">
+          <label htmlFor="fcfsWinners" className="control-label">
+            FCFS WL Winners:
+          </label>
+          <div className="number-input-group">
+            <input
+              type="number"
+              id="fcfsWinners"
+              className="number-input"
+              value={fcfsWinners}
+              min={0}
+              max={maxWinners - guaranteeWinners}
+              onChange={handleFcfsWinnersChange}
+              disabled={isDrawing || raffleComplete}
+            />
+            <div className="number-controls">
+              <button 
+                className="number-control" 
+                onClick={() => setFcfsWinners(prev => Math.min(prev + 1, maxWinners - guaranteeWinners))}
+                disabled={guaranteeWinners + fcfsWinners >= maxWinners || isDrawing || raffleComplete}
+              >
+                ▲
+              </button>
+              <button 
+                className="number-control" 
+                onClick={() => setFcfsWinners(prev => Math.max(prev - 1, 0))}
+                disabled={fcfsWinners <= 0 || isDrawing || raffleComplete}
               >
                 ▼
               </button>
@@ -86,7 +128,7 @@ export function RaffleControls({
         <button
           className={`raffle-button ${isDrawing ? 'loading' : ''} ${raffleComplete ? 'complete' : ''}`}
           onClick={handleStartRaffle}
-          disabled={isDrawing || raffleComplete || participants.length === 0}
+          disabled={isDrawing || raffleComplete || participants.length === 0 || (guaranteeWinners === 0 && fcfsWinners === 0)}
         >
           {isDrawing 
             ? "Drawing..." 
@@ -100,33 +142,77 @@ export function RaffleControls({
         <div className="winners-display">
           <h3 className="winners-title">🏆 Winners 🏆</h3>
           
-          <div className="winners-list">
-            {winners.map((winner, index) => (
-              <div key={winner.address} className="winner-card">
-                <div className="winner-number">#{index + 1}</div>
-                <div className="winner-info">
-                  <div className="winner-address">
-                    <a
-                      href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="contract-link"
-                    >
-                      {formatAddress(winner.address)}
-                    </a>
-                  </div>
-                  <div className="winner-stats">
-                    <span className="winner-power">
-                      Raffle Power: {winner.rafflePower.toLocaleString()}
-                    </span>
-                    <span className="winner-chance">
-                      Win Chance: {winner.percentage.toFixed(2)}%
-                    </span>
-                  </div>
-                </div>
+          {/* Guarantee WL Winners */}
+          {winners.filter(w => w.prizeType === 'Guarantee WL').length > 0 && (
+            <div className="prize-category">
+              <h4>Guarantee WL Winners</h4>
+              <div className="winners-list guarantee-winners">
+                {winners
+                  .filter(winner => winner.prizeType === 'Guarantee WL')
+                  .map((winner, index) => (
+                    <div key={winner.address} className="winner-card">
+                      <div className="winner-number">#{index + 1}</div>
+                      <div className="winner-info">
+                        <div className="winner-address">
+                          <a
+                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="contract-link"
+                          >
+                            {formatAddress(winner.address)}
+                          </a>
+                        </div>
+                        <div className="winner-stats">
+                          <span className="winner-power">
+                            Raffle Power: {winner.rafflePower.toLocaleString()}
+                          </span>
+                          <span className="winner-chance">
+                            Win Chance: {winner.percentage.toFixed(2)}%
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
               </div>
-            ))}
-          </div>
+            </div>
+          )}
+          
+          {/* FCFS WL Winners */}
+          {winners.filter(w => w.prizeType === 'FCFS WL').length > 0 && (
+            <div className="prize-category">
+              <h4>FCFS WL Winners</h4>
+              <div className="winners-list fcfs-winners">
+                {winners
+                  .filter(winner => winner.prizeType === 'FCFS WL')
+                  .map((winner, index) => (
+                    <div key={winner.address} className="winner-card">
+                      <div className="winner-number">#{index + 1}</div>
+                      <div className="winner-info">
+                        <div className="winner-address">
+                          <a
+                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="contract-link"
+                          >
+                            {formatAddress(winner.address)}
+                          </a>
+                        </div>
+                        <div className="winner-stats">
+                          <span className="winner-power">
+                            Raffle Power: {winner.rafflePower.toLocaleString()}
+                          </span>
+                          <span className="winner-chance">
+                            Win Chance: {winner.percentage.toFixed(2)}%
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          )}
           
           <div className="export-winners-container">
             <button
@@ -142,6 +228,166 @@ export function RaffleControls({
       )}
       
       <style jsx>{`
+        .raffle-controls {
+          display: flex;
+          flex-direction: column;
+          gap: 1rem;
+          margin-bottom: 2rem;
+        }
+        
+        .control-group {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+        
+        .control-label {
+          font-weight: 600;
+          font-size: 0.9rem;
+          color: #4a5568;
+        }
+        
+        .number-input-group {
+          display: flex;
+          align-items: center;
+        }
+        
+        .number-input {
+          width: 70px;
+          padding: 0.5rem;
+          border: 1px solid #e2e8f0;
+          border-radius: 0.25rem;
+          text-align: center;
+        }
+        
+        .number-controls {
+          display: flex;
+          flex-direction: column;
+          margin-left: 0.5rem;
+        }
+        
+        .number-control {
+          padding: 0;
+          width: 24px;
+          height: 16px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border: 1px solid #e2e8f0;
+          background-color: #f7fafc;
+          cursor: pointer;
+          font-size: 10px;
+        }
+        
+        .raffle-button {
+          padding: 0.75rem 1.5rem;
+          background-color: #4a5568;
+          color: white;
+          border: none;
+          border-radius: 0.25rem;
+          font-weight: 600;
+          cursor: pointer;
+          transition: all 0.2s ease;
+          margin-top: 1rem;
+          width: 100%;
+        }
+        
+        .raffle-button:hover {
+          background-color: #2d3748;
+        }
+        
+        .raffle-button:disabled {
+          background-color: #a0aec0;
+          cursor: not-allowed;
+        }
+        
+        .winners-display {
+          margin-top: 2rem;
+          border-top: 1px solid #e2e8f0;
+          padding-top: 2rem;
+        }
+        
+        .winners-title {
+          font-size: 1.5rem;
+          font-weight: 700;
+          margin-bottom: 1.5rem;
+          text-align: center;
+          color: #2d3748;
+        }
+        
+        .prize-category {
+          margin-bottom: 1.5rem;
+          border: 1px solid #e2e8f0;
+          border-radius: 0.5rem;
+          padding: 1rem;
+        }
+        
+        .prize-category h4 {
+          font-size: 1.1rem;
+          font-weight: 600;
+          margin-bottom: 1rem;
+          padding-bottom: 0.5rem;
+          border-bottom: 1px solid #e2e8f0;
+        }
+        
+        .winners-list {
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+        }
+        
+        .winner-card {
+          display: flex;
+          padding: 0.75rem;
+          border-radius: 0.25rem;
+          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        
+        .guarantee-winners .winner-card {
+          background-color: rgba(72, 187, 120, 0.1);
+          border-left: 4px solid #48bb78;
+        }
+        
+        .fcfs-winners .winner-card {
+          background-color: rgba(237, 137, 54, 0.1);
+          border-left: 4px solid #ed8936;
+        }
+        
+        .winner-number {
+          font-weight: 700;
+          font-size: 1.2rem;
+          margin-right: 1rem;
+          width: 2rem;
+          text-align: center;
+          align-self: center;
+          color: #2d3748;
+        }
+        
+        .winner-info {
+          flex: 1;
+        }
+        
+        .winner-address {
+          font-family: monospace;
+          margin-bottom: 0.25rem;
+        }
+        
+        .contract-link {
+          color: #4299e1;
+          text-decoration: none;
+        }
+        
+        .contract-link:hover {
+          text-decoration: underline;
+        }
+        
+        .winner-stats {
+          display: flex;
+          gap: 1rem;
+          font-size: 0.8rem;
+          color: #718096;
+        }
+        
         .export-winners-container {
           display: flex;
           justify-content: center;
@@ -177,6 +423,18 @@ export function RaffleControls({
         
         .export-icon {
           font-size: 1.2rem;
+        }
+        
+        @media (min-width: 640px) {
+          .raffle-controls {
+            flex-direction: row;
+            align-items: flex-end;
+          }
+          
+          .raffle-button {
+            width: auto;
+            margin-top: 0;
+          }
         }
       `}</style>
     </div>

--- a/src/components/Raffle/RaffleControls.tsx
+++ b/src/components/Raffle/RaffleControls.tsx
@@ -145,14 +145,17 @@ export function RaffleControls({
           {/* Guarantee WL Winners */}
           {winners.filter(w => w.prizeType === 'Guarantee WL').length > 0 && (
             <div className="prize-category">
-              <h4>Guarantee WL Winners</h4>
+              <div className="prize-header">
+                <div className="prize-icon guarantee-icon">🔐</div>
+                <h4>Guarantee WL Winners</h4>
+              </div>
               <div className="winners-grid guarantee-winners">
                 {winners
                   .filter(winner => winner.prizeType === 'Guarantee WL')
                   .map((winner, index) => (
                     <div key={winner.address} className="winner-card">
-                      <div className="winner-number">#{index + 1}</div>
-                      <div className="winner-address">
+                      <div className="card-top">
+                        <div className="winner-badge">{index + 1}</div>
                         <a
                           href={`https://marketplace.roninchain.com/account/${winner.address}`}
                           target="_blank"
@@ -162,12 +165,14 @@ export function RaffleControls({
                           {formatAddress(winner.address)}
                         </a>
                       </div>
-                      <div className="winner-stats">
-                        <div className="winner-power">
-                          Power: {winner.rafflePower.toLocaleString()}
+                      <div className="card-stats">
+                        <div className="stat-item">
+                          <span className="stat-label">Raffle Power:</span>
+                          <span className="stat-value">{winner.rafflePower.toLocaleString()}</span>
                         </div>
-                        <div className="winner-chance">
-                          Chance: {winner.percentage.toFixed(2)}%
+                        <div className="stat-item">
+                          <span className="stat-label">Win Chance:</span>
+                          <span className="stat-value">{winner.percentage.toFixed(2)}%</span>
                         </div>
                       </div>
                     </div>
@@ -179,14 +184,17 @@ export function RaffleControls({
           {/* FCFS WL Winners */}
           {winners.filter(w => w.prizeType === 'FCFS WL').length > 0 && (
             <div className="prize-category">
-              <h4>FCFS WL Winners</h4>
+              <div className="prize-header">
+                <div className="prize-icon fcfs-icon">🏃</div>
+                <h4>FCFS WL Winners</h4>
+              </div>
               <div className="winners-grid fcfs-winners">
                 {winners
                   .filter(winner => winner.prizeType === 'FCFS WL')
                   .map((winner, index) => (
                     <div key={winner.address} className="winner-card">
-                      <div className="winner-number">#{index + 1}</div>
-                      <div className="winner-address">
+                      <div className="card-top">
+                        <div className="winner-badge">{index + 1}</div>
                         <a
                           href={`https://marketplace.roninchain.com/account/${winner.address}`}
                           target="_blank"
@@ -196,12 +204,14 @@ export function RaffleControls({
                           {formatAddress(winner.address)}
                         </a>
                       </div>
-                      <div className="winner-stats">
-                        <div className="winner-power">
-                          Power: {winner.rafflePower.toLocaleString()}
+                      <div className="card-stats">
+                        <div className="stat-item">
+                          <span className="stat-label">Raffle Power:</span>
+                          <span className="stat-value">{winner.rafflePower.toLocaleString()}</span>
                         </div>
-                        <div className="winner-chance">
-                          Chance: {winner.percentage.toFixed(2)}%
+                        <div className="stat-item">
+                          <span className="stat-label">Win Chance:</span>
+                          <span className="stat-value">{winner.percentage.toFixed(2)}%</span>
                         </div>
                       </div>
                     </div>
@@ -304,95 +314,190 @@ export function RaffleControls({
         }
         
         .winners-title {
-          font-size: 1.5rem;
+          font-size: 1.8rem;
           font-weight: 700;
           margin-bottom: 1.5rem;
           text-align: center;
           color: #2d3748;
+          text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
         }
         
         .prize-category {
+          margin-bottom: 2rem;
+          border-radius: 0.75rem;
+          padding: 1.5rem;
+          background-color: #ffffff;
+          box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+        }
+        
+        .prize-header {
+          display: flex;
+          align-items: center;
           margin-bottom: 1.5rem;
-          border: 1px solid #e2e8f0;
-          border-radius: 0.5rem;
-          padding: 1rem;
+          border-bottom: 2px solid #f7fafc;
+          padding-bottom: 1rem;
+        }
+        
+        .prize-icon {
+          font-size: 1.5rem;
+          margin-right: 0.75rem;
+          width: 40px;
+          height: 40px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 50%;
+        }
+        
+        .guarantee-icon {
+          background-color: rgba(72, 187, 120, 0.15);
+          color: #2f855a;
+        }
+        
+        .fcfs-icon {
+          background-color: rgba(237, 137, 54, 0.15);
+          color: #c05621;
         }
         
         .prize-category h4 {
-          font-size: 1.1rem;
+          font-size: 1.25rem;
           font-weight: 600;
-          margin-bottom: 1rem;
-          padding-bottom: 0.5rem;
-          border-bottom: 1px solid #e2e8f0;
+          color: #2d3748;
+          margin: 0;
         }
         
         .winners-grid {
           display: grid;
-          grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+          grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
           gap: 1rem;
         }
         
         .winner-card {
-          border-radius: 0.375rem;
-          padding: 1rem;
-          box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+          border-radius: 0.75rem;
+          overflow: hidden;
+          transition: all 0.3s ease;
           display: flex;
           flex-direction: column;
+          height: 100%;
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
         
         .guarantee-winners .winner-card {
-          background-color: rgba(72, 187, 120, 0.1);
-          border-top: 4px solid #48bb78;
+          background: linear-gradient(to bottom, #f0fff4, #ffffff);
+          border: 1px solid #c6f6d5;
         }
         
         .fcfs-winners .winner-card {
+          background: linear-gradient(to bottom, #fffaf0, #ffffff);
+          border: 1px solid #feebc8;
+        }
+        
+        .winner-card:hover {
+          transform: translateY(-3px);
+          box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+        }
+        
+        .card-top {
+          padding: 1rem;
+          display: flex;
+          align-items: center;
+          position: relative;
+        }
+        
+        .guarantee-winners .card-top {
+          background-color: rgba(72, 187, 120, 0.1);
+          border-bottom: 2px solid rgba(72, 187, 120, 0.2);
+        }
+        
+        .fcfs-winners .card-top {
           background-color: rgba(237, 137, 54, 0.1);
-          border-top: 4px solid #ed8936;
+          border-bottom: 2px solid rgba(237, 137, 54, 0.2);
         }
         
-        .winner-number {
-          font-weight: 700;
-          font-size: 1.2rem;
-          color: #2d3748;
-          margin-bottom: 0.5rem;
+        .winner-badge {
+          width: 28px;
+          height: 28px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          border-radius: 50%;
+          font-weight: 800;
+          font-size: 0.9rem;
+          margin-right: 0.75rem;
+          flex-shrink: 0;
         }
         
-        .winner-address {
-          font-family: monospace;
-          margin-bottom: 0.75rem;
-          word-break: break-all;
+        .guarantee-winners .winner-badge {
+          background-color: #48bb78;
+          color: white;
+        }
+        
+        .fcfs-winners .winner-badge {
+          background-color: #ed8936;
+          color: white;
         }
         
         .contract-link {
-          color: #4299e1;
+          color: #4a5568;
           text-decoration: none;
+          font-family: monospace;
+          font-size: 0.9rem;
+          font-weight: 600;
+          transition: color 0.2s ease;
+          word-break: break-all;
         }
         
-        .contract-link:hover {
-          text-decoration: underline;
+        .guarantee-winners .contract-link:hover {
+          color: #2f855a;
         }
         
-        .winner-stats {
-          font-size: 0.8rem;
+        .fcfs-winners .contract-link:hover {
+          color: #c05621;
+        }
+        
+        .card-stats {
+          padding: 1rem;
+          display: flex;
+          flex-direction: column;
+          gap: 0.5rem;
+          background-color: #ffffff;
+          height: 100%;
+        }
+        
+        .stat-item {
+          display: flex;
+          justify-content: space-between;
+          font-size: 0.85rem;
+        }
+        
+        .stat-label {
           color: #718096;
-          margin-top: auto;
         }
         
-        .winner-power, .winner-chance {
-          margin-bottom: 0.25rem;
+        .stat-value {
+          font-weight: 600;
+          color: #2d3748;
+        }
+        
+        .guarantee-winners .stat-value {
+          color: #2f855a;
+        }
+        
+        .fcfs-winners .stat-value {
+          color: #c05621;
         }
         
         .export-winners-container {
           display: flex;
           justify-content: center;
-          margin-top: 1.5rem;
+          margin-top: 2rem;
         }
         
         .export-winners-btn {
           display: flex;
           align-items: center;
-          gap: 0.5rem;
-          padding: 0.75rem 1.5rem;
+          gap: 0.75rem;
+          padding: 0.875rem 1.75rem;
           background-color: #4CAF50;
           color: white;
           border: none;
@@ -400,23 +505,23 @@ export function RaffleControls({
           font-weight: 600;
           font-size: 1rem;
           cursor: pointer;
-          transition: all 0.2s ease;
-          box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+          transition: all 0.3s ease;
+          box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
         
         .export-winners-btn:hover {
           background-color: #45a049;
           transform: translateY(-2px);
-          box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+          box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
         }
         
         .export-winners-btn:active {
           transform: translateY(0);
-          box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1);
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
         
         .export-icon {
-          font-size: 1.2rem;
+          font-size: 1.25rem;
         }
         
         @media (min-width: 640px) {

--- a/src/components/Raffle/RaffleControls.tsx
+++ b/src/components/Raffle/RaffleControls.tsx
@@ -153,24 +153,22 @@ export function RaffleControls({
                   .filter(winner => winner.prizeType === 'Guarantee WL')
                   .map((winner, index) => (
                     <div key={winner.address} className="winner-card guarantee-card">
-                      <div className="card-content">
-                        <div className="winner-rank">{index + 1}</div>
-                        <div className="winner-info">
-                          <a
-                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="wallet-address"
-                          >
-                            {formatAddress(winner.address)}
-                          </a>
-                          <div className="winner-stats">
-                            <div className="stat">
-                              <span>Power:</span> {winner.rafflePower.toLocaleString()}
-                            </div>
-                            <div className="stat">
-                              <span>Chance:</span> {winner.percentage.toFixed(2)}%
-                            </div>
+                      <div className="winner-rank">{index + 1}</div>
+                      <div className="winner-content">
+                        <a
+                          href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="wallet-address"
+                        >
+                          {formatAddress(winner.address)}
+                        </a>
+                        <div className="winner-stats">
+                          <div className="power-stat">
+                            <span>{winner.rafflePower.toLocaleString()}</span> Power
+                          </div>
+                          <div className="chance-stat">
+                            <span>{winner.percentage.toFixed(1)}%</span> Chance
                           </div>
                         </div>
                       </div>
@@ -191,24 +189,22 @@ export function RaffleControls({
                   .filter(winner => winner.prizeType === 'FCFS WL')
                   .map((winner, index) => (
                     <div key={winner.address} className="winner-card fcfs-card">
-                      <div className="card-content">
-                        <div className="winner-rank">{index + 1}</div>
-                        <div className="winner-info">
-                          <a
-                            href={`https://marketplace.roninchain.com/account/${winner.address}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="wallet-address"
-                          >
-                            {formatAddress(winner.address)}
-                          </a>
-                          <div className="winner-stats">
-                            <div className="stat">
-                              <span>Power:</span> {winner.rafflePower.toLocaleString()}
-                            </div>
-                            <div className="stat">
-                              <span>Chance:</span> {winner.percentage.toFixed(2)}%
-                            </div>
+                      <div className="winner-rank">{index + 1}</div>
+                      <div className="winner-content">
+                        <a
+                          href={`https://marketplace.roninchain.com/account/${winner.address}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="wallet-address"
+                        >
+                          {formatAddress(winner.address)}
+                        </a>
+                        <div className="winner-stats">
+                          <div className="power-stat">
+                            <span>{winner.rafflePower.toLocaleString()}</span> Power
+                          </div>
+                          <div className="chance-stat">
+                            <span>{winner.percentage.toFixed(1)}%</span> Chance
                           </div>
                         </div>
                       </div>
@@ -321,9 +317,9 @@ export function RaffleControls({
         
         .prize-category {
           margin-bottom: 1.5rem;
-          border: 1px solid #e2e8f0;
           border-radius: 0.5rem;
           overflow: hidden;
+          background-color: white;
           box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         }
         
@@ -334,10 +330,12 @@ export function RaffleControls({
         
         .guarantee-header {
           background-color: rgba(72, 187, 120, 0.1);
+          border-bottom: 1px solid rgba(72, 187, 120, 0.2);
         }
         
         .fcfs-header {
           background-color: rgba(237, 137, 54, 0.1);
+          border-bottom: 1px solid rgba(237, 137, 54, 0.2);
         }
         
         .prize-header h4 {
@@ -350,25 +348,18 @@ export function RaffleControls({
         .winners-grid {
           display: grid;
           grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-          gap: 0.5rem;
+          gap: 0.75rem;
           padding: 0.75rem;
-          background-color: #f8fafc;
         }
         
         .winner-card {
-          background-color: white;
-          border-radius: 0.25rem;
-          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-          transition: transform 0.2s ease, box-shadow 0.2s ease;
+          display: flex;
+          align-items: stretch;
+          border-radius: 0.375rem;
           overflow: hidden;
-        }
-        
-        .guarantee-card {
-          border-left: 3px solid #48bb78;
-        }
-        
-        .fcfs-card {
-          border-left: 3px solid #ed8936;
+          background-color: white;
+          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+          transition: transform 0.2s ease, box-shadow 0.2s ease;
         }
         
         .winner-card:hover {
@@ -376,82 +367,95 @@ export function RaffleControls({
           box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
         }
         
-        .card-content {
-          display: flex;
-          padding: 0.75rem;
+        .guarantee-card {
+          border: 1px solid rgba(72, 187, 120, 0.2);
+        }
+        
+        .fcfs-card {
+          border: 1px solid rgba(237, 137, 54, 0.2);
         }
         
         .winner-rank {
-          width: 1.5rem;
-          height: 1.5rem;
-          background-color: #f7fafc;
+          width: 2rem;
           display: flex;
           align-items: center;
           justify-content: center;
           font-weight: 700;
-          font-size: 0.875rem;
-          color: #4a5568;
-          margin-right: 0.75rem;
-          border: 1px solid #e2e8f0;
+          font-size: 0.9rem;
+          color: white;
         }
         
         .guarantee-card .winner-rank {
-          color: #2f855a;
-          border-color: #c6f6d5;
-          background-color: #f0fff4;
+          background-color: #48bb78;
         }
         
         .fcfs-card .winner-rank {
-          color: #c05621;
-          border-color: #feebc8;
-          background-color: #fffaf0;
+          background-color: #ed8936;
         }
         
-        .winner-info {
+        .winner-content {
           flex: 1;
-          min-width: 0; /* Allow text truncation to work in flex child */
+          padding: 0.75rem;
+          display: flex;
+          flex-direction: column;
         }
         
         .wallet-address {
-          display: block;
           font-family: monospace;
-          font-size: 0.85rem;
-          color: #4a5568;
+          font-size: 0.9rem;
+          font-weight: 600;
           text-decoration: none;
+          padding: 0.25rem 0.5rem;
+          border-radius: 0.25rem;
           margin-bottom: 0.5rem;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
+          text-align: center;
+          transition: background-color 0.15s ease;
+        }
+        
+        .guarantee-card .wallet-address {
+          color: #2f855a;
+          background-color: rgba(72, 187, 120, 0.1);
         }
         
         .guarantee-card .wallet-address:hover {
-          color: #2f855a;
+          background-color: rgba(72, 187, 120, 0.2);
+        }
+        
+        .fcfs-card .wallet-address {
+          color: #c05621;
+          background-color: rgba(237, 137, 54, 0.1);
         }
         
         .fcfs-card .wallet-address:hover {
-          color: #c05621;
+          background-color: rgba(237, 137, 54, 0.2);
         }
         
         .winner-stats {
-          font-size: 0.75rem;
+          display: flex;
+          justify-content: space-between;
+          font-size: 0.7rem;
           color: #718096;
         }
         
-        .stat {
+        .power-stat, .chance-stat {
           display: flex;
-          justify-content: space-between;
+          flex-direction: column;
+          align-items: center;
         }
         
-        .stat span {
-          color: #a0aec0;
+        .power-stat span, .chance-stat span {
+          font-weight: 700;
+          font-size: 0.85rem;
         }
         
-        .guarantee-card .stat {
-          color: #38a169;
+        .guarantee-card .power-stat span, 
+        .guarantee-card .chance-stat span {
+          color: #2f855a;
         }
         
-        .fcfs-card .stat {
-          color: #dd6b20;
+        .fcfs-card .power-stat span, 
+        .fcfs-card .chance-stat span {
+          color: #c05621;
         }
         
         .export-winners-container {

--- a/src/pages/raffle.tsx
+++ b/src/pages/raffle.tsx
@@ -75,7 +75,7 @@ export default function RafflePage() {
               <section className="draw-section">
                 <h2 className="section-title">3. Draw Winners</h2>
                 <p className="section-desc">
-                  Select the number of winners to draw and click the button.
+                  Select the number of winners to draw for each category and click the button.
                   Winners will be selected randomly, with chances proportional to raffle power.
                 </p>
                 

--- a/src/utils/exportWinners.ts
+++ b/src/utils/exportWinners.ts
@@ -10,18 +10,40 @@ export function exportWinnersToCSV(winners: Participant[], filename = 'raffle-wi
   const exportFilename = `${filename}-${date}.csv`;
   
   // Create CSV headers and content
-  const headers = ['Rank', 'Wallet Address', 'Raffle Power', 'Win Chance (%)'];
+  const headers = ['Rank', 'Prize Type', 'Wallet Address', 'Raffle Power', 'Win Chance (%)'];
   
+  // Group winners by prize type
+  const guaranteeWinners = winners.filter(w => w.prizeType === 'Guarantee WL');
+  const fcfsWinners = winners.filter(w => w.prizeType === 'FCFS WL');
+  
+  // Create rows for each winner
+  const csvRows = [];
+  
+  // Add Guarantee WL winners
+  guaranteeWinners.forEach((winner, index) => {
+    csvRows.push([
+      index + 1,
+      'Guarantee WL',
+      winner.address,
+      winner.rafflePower,
+      winner.percentage.toFixed(2)
+    ].join(','));
+  });
+  
+  // Add FCFS WL winners
+  fcfsWinners.forEach((winner, index) => {
+    csvRows.push([
+      index + 1,
+      'FCFS WL',
+      winner.address,
+      winner.rafflePower,
+      winner.percentage.toFixed(2)
+    ].join(','));
+  });
+
   const csvContent = [
     headers.join(','),
-    ...winners.map((winner, index) => 
-      [
-        index + 1,
-        winner.address,
-        winner.rafflePower,
-        winner.percentage.toFixed(2)
-      ].join(',')
-    )
+    ...csvRows
   ].join('\n');
 
   // Create blob and download


### PR DESCRIPTION
This PR implements the dual raffle categories feature with the following enhancements:

## New Features
- Added support for two separate prize categories: Guarantee WL and FCFS WL
- Updated the UI to allow setting different winner counts for each category
- Modified the raffle algorithm to select winners for each category sequentially
- Enhanced the winners display with a stylish card-based grid layout
- Updated the CSV export to include prize category information

## UI/UX Improvements
- Implemented a clean, compact card design for raffle winners
- Added visual distinction between different prize categories (green for Guarantee WL, orange for FCFS WL)
- Maintained responsive layout that works well on different screen sizes
- Added subtle hover effects for better user interaction

## Technical Changes
- Updated the Participant interface to include prize type information
- Modified the raffle selection algorithm to ensure a participant can only win in one category
- Enhanced the export functionality to maintain prize category information

This implementation ensures that participants have a fair chance based on their raffle power while allowing for different prize category allocations.