### PR TITLE
Add Lord Staking Activity page

### DIFF
--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -28,6 +28,14 @@ export function Navigation() {
             </div>
           </Link>
         </li>
+        <li className={`nav-item ${isActive('/staking-activity')}`}>
+          <Link href="/staking-activity" style={{ textDecoration: 'none', color: 'inherit' }}>
+            <div className="nav-button">
+              <span className="nav-icon">📊</span>
+              <span className="nav-text">Staking Activity</span>
+            </div>
+          </Link>
+        </li>
         <li className={`nav-item ${isActive('/raffle')}`}>
           <Link href="/raffle" style={{ textDecoration: 'none', color: 'inherit' }}>
             <div className="nav-button">

--- a/src/components/Staking/ActivityFeed.tsx
+++ b/src/components/Staking/ActivityFeed.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { StakingActivity } from '../../types';
+import { ActivityItem } from './ActivityItem';
+
+interface ActivityFeedProps {
+  activities: StakingActivity[];
+  loading: boolean;
+  hasMore: boolean;
+  onLoadMore: () => void;
+}
+
+export function ActivityFeed({ activities, loading, hasMore, onLoadMore }: ActivityFeedProps) {
+  if (activities.length === 0 && !loading) {
+    return (
+      <div className="empty-state">
+        <p>No staking activity found.</p>
+        <style jsx>{`
+          .empty-state {
+            text-align: center;
+            padding: 40px;
+            color: #718096;
+          }
+        `}</style>
+      </div>
+    );
+  }
+  
+  return (
+    <div className="activity-feed">
+      {activities.map(activity => (
+        <ActivityItem 
+          key={`${activity.transactionHash}-${activity.tokenId}`} 
+          activity={activity} 
+        />
+      ))}
+      
+      {loading && (
+        <div className="loading-indicator">
+          <div className="loading-spinner"></div>
+          <p>Loading activity...</p>
+        </div>
+      )}
+      
+      {!loading && hasMore && (
+        <div className="load-more-container">
+          <button className="load-more-button" onClick={onLoadMore}>
+            Load More Activity
+          </button>
+        </div>
+      )}
+      
+      <style jsx>{`
+        .activity-feed {
+          width: 100%;
+        }
+        
+        .loading-indicator {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 20px;
+          margin-top: 20px;
+          color: #718096;
+        }
+        
+        .loading-spinner {
+          width: 30px;
+          height: 30px;
+          border: 3px solid #e2e8f0;
+          border-top: 3px solid #4a5568;
+          border-radius: 50%;
+          animation: spin 1s linear infinite;
+          margin-bottom: 10px;
+        }
+        
+        @keyframes spin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+        
+        .load-more-container {
+          display: flex;
+          justify-content: center;
+          margin: 20px 0;
+        }
+        
+        .load-more-button {
+          background-color: #4a5568;
+          color: white;
+          border: none;
+          padding: 10px 16px;
+          border-radius: 4px;
+          font-weight: 500;
+          cursor: pointer;
+          transition: background-color 0.2s;
+        }
+        
+        .load-more-button:hover {
+          background-color: #2d3748;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/components/Staking/ActivityItem.tsx
+++ b/src/components/Staking/ActivityItem.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { StakingActivity } from '../../types';
+
+interface ActivityItemProps {
+  activity: StakingActivity;
+}
+
+export function ActivityItem({ activity }: ActivityItemProps) {
+  const { actionType, tokenId, timestamp, owner, transactionHash } = activity;
+  
+  // Format the timestamp
+  const date = new Date(timestamp * 1000);
+  const formattedDate = date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  
+  const formattedTime = date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  
+  // Format wallet address for display
+  const formatAddress = (address: string) => {
+    return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
+  };
+  
+  // Transaction link
+  const transactionLink = `https://app.roninchain.com/tx/${transactionHash}`;
+  
+  // Different styling based on action type
+  const isStake = actionType === 'stake';
+  const actionClass = isStake ? 'stake-action' : 'unstake-action';
+  const actionIcon = isStake ? '🔒' : '🔓';
+  const actionText = isStake ? 'Staked' : 'Unstaked';
+  
+  return (
+    <div className={`activity-item ${actionClass}`}>
+      <div className="action-indicator">
+        <div className="action-icon">{actionIcon}</div>
+      </div>
+      
+      <div className="activity-content">
+        <div className="activity-header">
+          <span className="action-type">{actionText}</span>
+          <span className="lord-id">Lord #{tokenId}</span>
+        </div>
+        
+        <div className="activity-details">
+          <div className="owner-info">
+            <span className="detail-label">Owner:</span>
+            <a
+              href={`https://app.roninchain.com/address/${owner}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="address-link"
+            >
+              {formatAddress(owner)}
+            </a>
+          </div>
+          
+          <div className="transaction-info">
+            <span className="detail-label">Tx:</span>
+            <a
+              href={transactionLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transaction-link"
+            >
+              {formatAddress(transactionHash)}
+            </a>
+          </div>
+        </div>
+        
+        <div className="timestamp">
+          {formattedDate} at {formattedTime}
+        </div>
+      </div>
+      
+      <style jsx>{`
+        .activity-item {
+          display: flex;
+          padding: 16px;
+          border-radius: 8px;
+          margin-bottom: 16px;
+          background-color: white;
+          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+          position: relative;
+          overflow: hidden;
+        }
+        
+        .stake-action {
+          border-left: 4px solid #4CAF50;
+        }
+        
+        .unstake-action {
+          border-left: 4px solid #f44336;
+        }
+        
+        .action-indicator {
+          margin-right: 16px;
+          display: flex;
+          align-items: flex-start;
+          padding-top: 2px;
+        }
+        
+        .action-icon {
+          font-size: 20px;
+        }
+        
+        .activity-content {
+          flex: 1;
+        }
+        
+        .activity-header {
+          display: flex;
+          align-items: center;
+          margin-bottom: 8px;
+        }
+        
+        .action-type {
+          font-weight: 600;
+          font-size: 16px;
+          margin-right: 8px;
+        }
+        
+        .stake-action .action-type {
+          color: #4CAF50;
+        }
+        
+        .unstake-action .action-type {
+          color: #f44336;
+        }
+        
+        .lord-id {
+          font-weight: 500;
+          color: #4a5568;
+        }
+        
+        .activity-details {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 16px;
+          margin-bottom: 8px;
+          font-size: 14px;
+        }
+        
+        .owner-info, .transaction-info {
+          display: flex;
+          align-items: center;
+        }
+        
+        .detail-label {
+          color: #718096;
+          margin-right: 6px;
+        }
+        
+        .address-link, .transaction-link {
+          color: #4a5568;
+          text-decoration: none;
+          font-family: monospace;
+          transition: color 0.2s;
+        }
+        
+        .address-link:hover, .transaction-link:hover {
+          text-decoration: underline;
+          color: #2d3748;
+        }
+        
+        .timestamp {
+          font-size: 12px;
+          color: #718096;
+        }
+        
+        @media (max-width: 480px) {
+          .activity-details {
+            flex-direction: column;
+            gap: 8px;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/hooks/useStakingActivity.ts
+++ b/src/hooks/useStakingActivity.ts
@@ -1,0 +1,60 @@
+import { useState, useEffect, useCallback } from 'react';
+import { StakingActivity } from '../types';
+
+export function useStakingActivity() {
+  const [activities, setActivities] = useState<StakingActivity[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [page, setPage] = useState(1);
+  
+  const fetchActivity = useCallback(async (pageToFetch = 1) => {
+    try {
+      setLoading(true);
+      setError(null);
+      
+      const response = await fetch(`/api/staking-activity?page=${pageToFetch}`);
+      
+      if (!response.ok) {
+        throw new Error(`API request failed: ${response.statusText}`);
+      }
+      
+      const data = await response.json();
+      
+      if (pageToFetch === 1) {
+        setActivities(data.activities);
+      } else {
+        setActivities(prev => [...prev, ...data.activities]);
+      }
+      
+      setHasMore(data.hasMore);
+      setLoading(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch staking activity');
+      console.error('Error fetching staking activity:', err);
+      setLoading(false);
+    }
+  }, []);
+  
+  // Initial fetch
+  useEffect(() => {
+    fetchActivity(1);
+  }, [fetchActivity]);
+  
+  // Function to load more activities
+  const loadMore = useCallback(() => {
+    if (!loading && hasMore) {
+      const nextPage = page + 1;
+      setPage(nextPage);
+      fetchActivity(nextPage);
+    }
+  }, [loading, hasMore, page, fetchActivity]);
+  
+  return {
+    activities,
+    loading,
+    error,
+    hasMore,
+    loadMore
+  };
+}

--- a/src/pages/api/staking-activity.ts
+++ b/src/pages/api/staking-activity.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { fetchStakingActivity } from '../../services/activity';
+import { StakingActivity } from '../../types';
+import { getFromCache, setCache } from '../../utils/redis';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  try {
+    const { page = '1', limit = '20' } = req.query;
+    
+    const pageInt = parseInt(page as string);
+    const limitInt = Math.min(parseInt(limit as string), 50); // Cap at 50 items per page
+    
+    const cacheKey = `staking-activity:${pageInt}-${limitInt}`;
+    
+    // Try to get from cache first
+    const cachedActivities = await getFromCache<StakingActivity[]>(cacheKey);
+    
+    if (cachedActivities && cachedActivities.length > 0) {
+      console.log(`Found ${cachedActivities.length} activities in cache for key ${cacheKey}`);
+      
+      res.status(200).json({
+        activities: cachedActivities,
+        hasMore: cachedActivities.length === limitInt,
+        page: pageInt,
+        fromCache: true
+      });
+      return;
+    }
+    
+    // Fetch fresh data if not in cache
+    const activities = await fetchStakingActivity(limitInt);
+    
+    // Cache the results for 5 minutes (300 seconds)
+    // Short cache time since we want relatively fresh activity data
+    await setCache(cacheKey, activities, 300);
+    
+    res.status(200).json({
+      activities,
+      hasMore: activities.length === limitInt,
+      page: pageInt,
+      fromCache: false
+    });
+  } catch (error) {
+    console.error('API Error:', error);
+    res.status(500).json({ 
+      error: 'Failed to fetch staking activity data',
+      details: error instanceof Error ? error.message : 'Unknown error'
+    });
+  }
+}

--- a/src/pages/staking-activity.tsx
+++ b/src/pages/staking-activity.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import Head from 'next/head';
+import { EnhancedLayout } from '../components/Layout/EnhancedLayout';
+import { ActivityFeed } from '../components/Staking/ActivityFeed';
+import { useStakingActivity } from '../hooks/useStakingActivity';
+
+export default function StakingActivityPage() {
+  const { activities, loading, error, hasMore, loadMore } = useStakingActivity();
+
+  return (
+    <>
+      <Head>
+        <title>Wild Forest: Lord Staking Activity</title>
+        <meta name="description" content="Track staking and unstaking activity for Wild Forest Lords NFTs" />
+        <link rel="icon" href="/images/favicon.ico" />
+      </Head>
+
+      <EnhancedLayout>
+        <div className="staking-activity-page">
+          <div className="page-header">
+            <h1 className="page-title">Lord Staking Activity</h1>
+            <p className="page-description">
+              Track real-time staking and unstaking transactions for Wild Forest Lords NFTs
+            </p>
+          </div>
+
+          {error && (
+            <div className="error-message">
+              <p>{error}</p>
+            </div>
+          )}
+
+          <ActivityFeed 
+            activities={activities} 
+            loading={loading} 
+            hasMore={hasMore} 
+            onLoadMore={loadMore} 
+          />
+        </div>
+
+        <style jsx>{`
+          .staking-activity-page {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 24px 16px;
+          }
+          
+          .page-header {
+            text-align: center;
+            margin-bottom: 32px;
+          }
+          
+          .page-title {
+            font-size: 2rem;
+            font-weight: 700;
+            margin-bottom: 12px;
+            color: #2d3748;
+          }
+          
+          .page-description {
+            font-size: 1rem;
+            color: #718096;
+            max-width: 600px;
+            margin: 0 auto;
+          }
+          
+          .error-message {
+            background-color: #fff5f5;
+            color: #e53e3e;
+            padding: 16px;
+            border-radius: 8px;
+            margin-bottom: 24px;
+            border-left: 4px solid #e53e3e;
+          }
+          
+          @media (max-width: 640px) {
+            .page-title {
+              font-size: 1.75rem;
+            }
+            
+            .page-description {
+              font-size: 0.9rem;
+            }
+          }
+        `}</style>
+      </EnhancedLayout>
+    </>
+  );
+}

--- a/src/services/activity.ts
+++ b/src/services/activity.ts
@@ -1,0 +1,175 @@
+import { StakingActivity } from '../types';
+
+const RONIN_RPC = 'https://api.roninchain.com/rpc';
+const STAKING_CONTRACT = '0xfb597d6fa6c08f5434e6ecf69114497343ae13dd';
+
+// Method signature for staking and unstaking events
+const STAKE_EVENT_SIGNATURE = '0xc5ec8c8b2ed4ba4bab7c52c7a0d0bd811f1fda884c3f41693d7ca5725e3ac7f7';
+const UNSTAKE_EVENT_SIGNATURE = '0xe4079ae26abd3e5f28603fab4d36af7835b5301f8c873a3e9a8fd5d7a5ea5da7';
+
+interface LogEntry {
+  address: string;
+  blockNumber: string;
+  data: string;
+  logIndex: string;
+  removed: boolean;
+  topics: string[];
+  transactionHash: string;
+  transactionIndex: string;
+}
+
+interface RPCLogsResponse {
+  jsonrpc: string;
+  id: number;
+  result?: LogEntry[];
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+interface RPCBlockResponse {
+  jsonrpc: string;
+  id: number;
+  result?: {
+    timestamp: string;
+    [key: string]: any;
+  };
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+export async function fetchStakingActivity(limit: number = 50, fromBlock?: number): Promise<StakingActivity[]> {
+  try {
+    const stakeEvents = await fetchEvents(STAKE_EVENT_SIGNATURE, limit, fromBlock);
+    const unstakeEvents = await fetchEvents(UNSTAKE_EVENT_SIGNATURE, limit, fromBlock);
+
+    // Process and combine both types of events
+    const stakingActivities = await processStakeEvents(stakeEvents);
+    const unstakingActivities = await processUnstakeEvents(unstakeEvents);
+
+    // Combine and sort by timestamp (most recent first)
+    const allActivities = [...stakingActivities, ...unstakingActivities]
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, limit);
+
+    return allActivities;
+  } catch (error) {
+    console.error('Failed to fetch staking activity:', error);
+    return [];
+  }
+}
+
+async function fetchEvents(eventSignature: string, limit: number, fromBlock?: number): Promise<LogEntry[]> {
+  const payload = {
+    jsonrpc: '2.0',
+    id: Date.now(),
+    method: 'eth_getLogs',
+    params: [
+      {
+        address: STAKING_CONTRACT,
+        topics: [eventSignature],
+        fromBlock: fromBlock ? `0x${fromBlock.toString(16)}` : 'latest',
+        toBlock: 'latest'
+      }
+    ]
+  };
+
+  const response = await fetch(RONIN_RPC, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data: RPCLogsResponse = await response.json();
+
+  if (data.error) {
+    throw new Error(`RPC error: ${data.error.message}`);
+  }
+
+  // Return the most recent events up to the limit
+  return data.result ? data.result.slice(-limit) : [];
+}
+
+async function processStakeEvents(events: LogEntry[]): Promise<StakingActivity[]> {
+  const activities: StakingActivity[] = [];
+
+  for (const event of events) {
+    // Extract tokenId from the second topic
+    const tokenId = parseInt(event.topics[1], 16).toString();
+    
+    // Extract owner from the third topic
+    const owner = `0x${event.topics[2].slice(26).toLowerCase()}`;
+
+    // Get block timestamp
+    const timestamp = await getBlockTimestamp(parseInt(event.blockNumber, 16));
+
+    activities.push({
+      transactionHash: event.transactionHash,
+      timestamp,
+      tokenId,
+      owner,
+      actionType: 'stake',
+      blockNumber: parseInt(event.blockNumber, 16),
+      attributes: {}
+    });
+  }
+
+  return activities;
+}
+
+async function processUnstakeEvents(events: LogEntry[]): Promise<StakingActivity[]> {
+  const activities: StakingActivity[] = [];
+
+  for (const event of events) {
+    // Extract tokenId from the second topic
+    const tokenId = parseInt(event.topics[1], 16).toString();
+    
+    // Extract owner from the third topic
+    const owner = `0x${event.topics[2].slice(26).toLowerCase()}`;
+
+    // Get block timestamp
+    const timestamp = await getBlockTimestamp(parseInt(event.blockNumber, 16));
+
+    activities.push({
+      transactionHash: event.transactionHash,
+      timestamp,
+      tokenId,
+      owner,
+      actionType: 'unstake',
+      blockNumber: parseInt(event.blockNumber, 16),
+      attributes: {}
+    });
+  }
+
+  return activities;
+}
+
+async function getBlockTimestamp(blockNumber: number): Promise<number> {
+  const payload = {
+    jsonrpc: '2.0',
+    id: Date.now(),
+    method: 'eth_getBlockByNumber',
+    params: [`0x${blockNumber.toString(16)}`, false]
+  };
+
+  const response = await fetch(RONIN_RPC, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const data: RPCBlockResponse = await response.json();
+
+  if (data.error) {
+    throw new Error(`RPC error: ${data.error.message}`);
+  }
+
+  return data.result ? parseInt(data.result.timestamp, 16) : 0;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,3 +57,24 @@ export interface Lord {
   
   export const LORD_SPECIES = ['All', 'Wolf', 'Owl', 'Raven', 'Boar', 'Fox'];
   export const LORD_RARITIES = ['All', 'Rare', 'Epic', 'Legendary', 'Mystic'];
+
+  // New types for staking activity
+  export interface StakingActivity {
+    transactionHash: string;
+    timestamp: number;
+    tokenId: string;
+    tokenName?: string;
+    owner: string;
+    actionType: 'stake' | 'unstake';
+    blockNumber: number;
+    attributes?: {
+      rank?: string;
+      specie?: string;
+    };
+  }
+
+  export interface StakingActivityResponse {
+    activities: StakingActivity[];
+    nextCursor?: string;
+    hasMore: boolean;
+  }


### PR DESCRIPTION
This PR adds a new "Lord Staking Activity" page to the Wild Forest Lords Dashboard that shows a chronological feed of staking and unstaking transactions.

## New Features
- Added a new page that displays staking and unstaking activity in real-time
- Color-coded transaction cards (green for staking, red for unstaking)
- Pagination support for loading more historical activity
- Links to blockchain explorer for transactions and wallets

## Technical Implementation
- Created a service to fetch staking events from the blockchain
- Added a custom React hook for activity data fetching
- Implemented API endpoint with caching for performance
- Built UI components for activity feed display

## Design Considerations
- Responsive design that works on all screen sizes
- Clear visual distinction between staking and unstaking events
- Easy-to-scan transaction details
- Consistent with existing site styling

## How to Test
1. Navigate to the new "Staking Activity" page via the navigation bar
2. Observe the color-coded staking/unstaking transactions
3. Click "Load More" to see older transactions
4. Click on transaction hashes or wallet addresses to see them in the blockchain explorer